### PR TITLE
Fix histogram division by zero on first play

### DIFF
--- a/src/components/stats/Histogram.tsx
+++ b/src/components/stats/Histogram.tsx
@@ -7,7 +7,7 @@ type Props = {
 
 export const Histogram = ({ gameStats }: Props) => {
   const winDistribution = gameStats.winDistribution
-  const maxValue = Math.max(...winDistribution)
+  const maxValue = Math.max(...winDistribution) || 1
 
   return (
     <div className="columns-1 justify-left m-2 text-sm dark:text-white">


### PR DESCRIPTION
## Summary

- When no games have been won yet, `Math.max(...winDistribution)` returns `0`, causing every progress bar width to be `NaN`
- Guard with `|| 1` so the histogram renders cleanly even before the first win

Closes #15

## Test plan

- [ ] Open the Stats modal before completing any game — verify histogram bars render at 0% width rather than disappearing

🤖 Generated with [Claude Code](https://claude.com/claude-code)