### PR TITLE
Guard localStorage JSON.parse against corrupted data

### DIFF
--- a/src/lib/localStorage.ts
+++ b/src/lib/localStorage.ts
@@ -10,8 +10,12 @@ export const saveGameStateToLocalStorage = (gameState: StoredGameState) => {
 }
 
 export const loadGameStateFromLocalStorage = () => {
-  const state = localStorage.getItem(gameStateKey)
-  return state ? (JSON.parse(state) as StoredGameState) : null
+  try {
+    const state = localStorage.getItem(gameStateKey)
+    return state ? (JSON.parse(state) as StoredGameState) : null
+  } catch {
+    return null
+  }
 }
 
 const gameStatKey = 'gameStats'
@@ -30,6 +34,10 @@ export const saveStatsToLocalStorage = (gameStats: GameStats) => {
 }
 
 export const loadStatsFromLocalStorage = () => {
-  const stats = localStorage.getItem(gameStatKey)
-  return stats ? (JSON.parse(stats) as GameStats) : null
+  try {
+    const stats = localStorage.getItem(gameStatKey)
+    return stats ? (JSON.parse(stats) as GameStats) : null
+  } catch {
+    return null
+  }
 }


### PR DESCRIPTION
## Summary

- Both `loadGameStateFromLocalStorage` and `loadStatsFromLocalStorage` called `JSON.parse` without error handling
- Corrupted or manually edited localStorage values would throw `SyntaxError` and crash the entire app
- Wrap each in `try/catch` and return `null` on failure, which the callers already handle as "no saved state"

Closes #18

## Test plan

- [ ] Manually set `localStorage.gameState = "invalid json"` in DevTools, then reload — verify the game starts fresh instead of crashing

🤖 Generated with [Claude Code](https://claude.com/claude-code)