### PR TITLE
Handle rejected navigator.share and clipboard promises

### DIFF
--- a/src/lib/share.ts
+++ b/src/lib/share.ts
@@ -28,14 +28,12 @@ export const vkStatus = (guesses: string[], lost: boolean) => {
 
 export const shareStatus = (guesses: string[], lost: boolean) => {
   log('share')
-  navigator.share({
-    text: getText(guesses, lost),
-  })
+  navigator.share({ text: getText(guesses, lost) }).catch(() => {})
 }
 
 export const copyStatus = (guesses: string[], lost: boolean) => {
   log('copy')
-  navigator.clipboard.writeText(getText(guesses, lost))
+  navigator.clipboard.writeText(getText(guesses, lost)).catch(() => {})
 }
 
 const getStats = (guesses: string[], lost: boolean) => {


### PR DESCRIPTION
## Summary

- `navigator.share()` and `navigator.clipboard.writeText()` both return Promises that were unhandled
- On unsupported browsers or when the user denies permission they reject, producing unhandled rejection warnings
- Add `.catch(() => {})` to explicitly acknowledge and suppress expected failures

Closes #19

## Test plan

- [ ] In a browser that doesn't support `navigator.share` (e.g., Firefox), click the Share button — verify no console error appears
- [ ] Deny clipboard permission and click Copy — verify no crash or unhandled rejection

🤖 Generated with [Claude Code](https://claude.com/claude-code)