### PR TITLE
Replace Array.includes word lookup with Set for O(1) performance

### DIFF
--- a/src/lib/words.ts
+++ b/src/lib/words.ts
@@ -1,11 +1,10 @@
 import { WORDS } from '../constants/wordlist'
 import { VALID_GUESSES } from '../constants/validGuesses'
 
+const wordSet = new Set([...WORDS, ...VALID_GUESSES])
+
 export const isWordInWordList = (word: string) => {
-  return (
-    WORDS.includes(word.toLowerCase()) ||
-    VALID_GUESSES.includes(word.toLowerCase())
-  )
+  return wordSet.has(word.toLowerCase())
 }
 
 export const isWinningWord = (word: string) => {


### PR DESCRIPTION
## Summary

- `isWordInWordList` used `Array.includes` on both `WORDS` and `VALID_GUESSES` — O(n) per call, fired on every Enter keypress
- Build a `Set` once at module load time and use `Set.has` for O(1) lookup

Closes #20

## Test plan

- [ ] Run `npm test` — all existing tests pass
- [ ] Play a round and verify valid/invalid word detection still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)