### PR TITLE
Replace 'any' with 'unknown' for analytics event params

### DIFF
--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -17,9 +17,7 @@ const firebaseAnalytics = isSupported().then((yes) =>
 
 export const log = (
   eventName: string,
-  eventParams?: {
-    [key: string]: any
-  }
+  eventParams?: Record<string, unknown>
 ) => {
   firebaseAnalytics.then((analytics) => {
     if (analytics != null) {


### PR DESCRIPTION
## Summary

- `eventParams` in `src/lib/analytics.ts` used `[key: string]: any`, bypassing TypeScript type-checking for all analytics calls
- Replace with `Record<string, unknown>` — the correct type for an open-ended object with unspecified value types

Closes #22

## Test plan

- [ ] Run `npm test` — all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)