### PR TITLE
Simplify isDarkMode initializer, read localStorage once

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -48,12 +48,9 @@ function App() {
   const [isSettingsModalOpen, setIsSettingsModalOpen] = useState(false)
   const [isWordNotFoundAlertOpen, setIsWordNotFoundAlertOpen] = useState(false)
   const [isGameLost, setIsGameLost] = useState(false)
+  const savedTheme = localStorage.getItem('theme')
   const [isDarkMode, setIsDarkMode] = useState(
-    localStorage.getItem('theme')
-      ? localStorage.getItem('theme') === 'dark'
-      : prefersDarkMode
-      ? true
-      : false
+    savedTheme ? savedTheme === 'dark' : prefersDarkMode
   )
   const [keyboardLayout, setKeyboardLayout] = useState(
     localStorage.getItem('keyboard') ?? 'default'


### PR DESCRIPTION
## Summary

- `localStorage.getItem('theme')` was called twice in the `isDarkMode` useState initializer
- The trailing `? true : false` was also redundant — `prefersDarkMode` is already a boolean
- Read into `savedTheme` once and simplify the expression

Closes #16

## Test plan

- [ ] Run `npm test` — all tests pass
- [ ] Toggle dark mode, reload — verify preference is preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)