### PR TITLE
Remove dead length check in onEnter

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -160,11 +160,7 @@ function App() {
 
     const winningWord = isWinningWord(currentGuess)
 
-    if (
-      currentGuess.length === MAX_WORD_LENGTH &&
-      guesses.length < MAX_CHALLENGES &&
-      !isGameWon
-    ) {
+    if (guesses.length < MAX_CHALLENGES && !isGameWon) {
       setGuesses([...guesses, currentGuess])
       setCurrentGuess('')
 


### PR DESCRIPTION
## Summary

- Inside `onEnter`, the function returns early at the top if `currentGuess.length !== MAX_WORD_LENGTH`
- The same condition was redundantly repeated in the final `if` block, where it can never be false
- Remove the unreachable checks to clarify intent

Closes #17

## Test plan

- [ ] Run `npm test` — all tests pass
- [ ] Play a full game to win/lose — verify submit behaviour is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)