### PR TITLE
Wrap header icon buttons in semantic <button> with aria-label

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -191,27 +191,36 @@ function App() {
         >
           {GAME_TITLE}
         </h1>
-        <InformationCircleIcon
-          className="h-6 w-6 mr-2 cursor-pointer dark:stroke-white"
+        <button
+          aria-label="How to play"
+          className="p-0 border-0 bg-transparent"
           onClick={() => {
             log('open_info_modal')
             setIsInfoModalOpen(true)
           }}
-        />
-        <ChartBarIcon
-          className="h-6 w-6 mr-2 cursor-pointer dark:stroke-white"
+        >
+          <InformationCircleIcon className="h-6 w-6 mr-2 cursor-pointer dark:stroke-white" />
+        </button>
+        <button
+          aria-label="Statistics"
+          className="p-0 border-0 bg-transparent"
           onClick={() => {
             log('open_stats_modal')
             setIsStatsModalOpen(true)
           }}
-        />
-        <CogIcon
-          className="h-6 w-6 mr-3 cursor-pointer dark:stroke-white"
+        >
+          <ChartBarIcon className="h-6 w-6 mr-2 cursor-pointer dark:stroke-white" />
+        </button>
+        <button
+          aria-label="Settings"
+          className="p-0 border-0 bg-transparent"
           onClick={() => {
             log('open_settings_modal')
             setIsSettingsModalOpen(true)
           }}
-        />
+        >
+          <CogIcon className="h-6 w-6 mr-3 cursor-pointer dark:stroke-white" />
+        </button>
       </div>
       <Grid
         guesses={guesses}


### PR DESCRIPTION
## Summary

- The three header icons (Info, Stats, Settings) were bare SVGs with `onClick` handlers — not semantic buttons and invisible to screen readers
- Wrap each in a `<button>` element with a descriptive `aria-label`

Closes #21

## Test plan

- [ ] Run `npm test` — all tests pass
- [ ] Inspect with a screen reader or browser accessibility tree — verify the three buttons are announced as "How to play", "Statistics", "Settings"
- [ ] Click each button — verify modals still open correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)