### PR TITLE
Fix CI lint job to use project's pinned Prettier version

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,7 +10,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Prettify code
-        uses: creyD/prettier_action@v4.2
+      - uses: actions/setup-node@v3
         with:
-          prettier_options: --check src
+          node-version: 16
+          cache: npm
+      - run: npm ci
+      - run: npm run lint


### PR DESCRIPTION
## Summary

- `creyD/prettier_action@v4.2` installs its own copy of Prettier (latest at run time), which diverges from the project's pinned `2.5.1` in `package.json`
- This causes files that are correctly formatted for 2.5.1 to fail CI
- Replace the external action with `npm ci && npm run lint` so CI always uses the exact version from `package-lock.json`

## Test plan

- [ ] Merge this PR first so all subsequent PRs are checked with the correct Prettier version

🤖 Generated with [Claude Code](https://claude.com/claude-code)